### PR TITLE
Change current_jobs to be inclusive 30 days instead of 90 days.

### DIFF
--- a/app/models/job_posting.rb
+++ b/app/models/job_posting.rb
@@ -5,7 +5,7 @@ class JobPosting < ActiveRecord::Base
   validates :how_to_apply, presence: true
 
   def self.current_jobs
-    current_dates = 90.days.ago..Date.current.end_of_day
+    current_dates = 30.days.ago.beginning_of_day..Date.current.end_of_day
     where(created_at: current_dates).order(created_at: :desc)
   end
 

--- a/spec/models/job_posting_spec.rb
+++ b/spec/models/job_posting_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe JobPosting, type: :model do
 
   describe ".current_jobs" do
     it "should only return jobs created in the last 90 days" do
-      old_job = create(:job_posting, created_at: Date.current - 91.days)
+      old_job = create(:job_posting, created_at: Date.current - 31.days)
       new_job = create(:job_posting)
       expect(JobPosting.current_jobs).to eq [new_job]
     end

--- a/spec/models/job_posting_spec.rb
+++ b/spec/models/job_posting_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe JobPosting, type: :model do
   it { should validate_presence_of :how_to_apply }
 
   describe ".current_jobs" do
-    it "should only return jobs created in the last 90 days" do
+    it "should only return jobs created in the last 30 days" do
       old_job = create(:job_posting, created_at: Date.current - 31.days)
       new_job = create(:job_posting)
       expect(JobPosting.current_jobs).to eq [new_job]


### PR DESCRIPTION
This addresses issue #21.

I made the beginning of the 30 day window inclusive by using `beginning_of_day`. If that's not preferred, let me know.