### PR TITLE
Remove unnecessary 'flex-direction' to fix footer in Safari.

### DIFF
--- a/app/assets/stylesheets/sections/_content.scss
+++ b/app/assets/stylesheets/sections/_content.scss
@@ -10,9 +10,6 @@
     padding: 5px;
     width: $main-content-width;
     margin: 0 auto;
-
-    flex-direction: column;
-    flex: 1;
   }
 
   .title {


### PR DESCRIPTION
I've tested this on Chrome 43.0.2357.130 and Safari 9.

This resolves the footer placement bug in #28.