### PR TITLE
Add Akismet for spam filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'redcarpet'
 gem 'autoprefixer-rails'
 
 gem 'ransack', '~> 1.6.6'
+gem 'rakismet', '~> 1.5.1'
 
 group :production, :acceptance do
   gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
+    rakismet (1.5.1)
     ransack (1.6.6)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -366,6 +367,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 4.2.1)
   rails_stdout_logging
+  rakismet (~> 1.5.1)
   ransack (~> 1.6.6)
   rb-fsevent
   redcarpet
@@ -380,4 +382,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/app/admin/job_posting.rb
+++ b/app/admin/job_posting.rb
@@ -4,25 +4,44 @@ ActiveAdmin.register JobPosting do
     :description,
     :how_to_apply,
     :full_time,
-    :company
+    :company,
+    :akismet_spam,
+    :user_ip,
+    :user_agent,
+    :referrer
   )
 
+  index do
+    id_column
+    column :company
+    column :full_time
+    column :title
+    column :description
+    column :created_at
+    column 'Is spam?', :akismet_spam
+    actions
+  end
+
   member_action :spam, method: :put do
+    resource.akismet_spam = true
+    resource.save
     resource.spam!
-    redirect_to resource_path, notice: 'Marked as spam!'
+    redirect_to resource_path, notice: 'Successfully marked as spam!'
   end
 
   member_action :ham, method: :put do
+    resource.akismet_spam = false
+    resource.save
     resource.ham!
-    redirect_to resource_path, notice: 'Marked as ham!'
+    redirect_to resource_path, notice: 'Successfully reported false positive!'
   end
 
   action_item :view, only: :show do
-    link_to 'Mark Spam', spam_admin_job_posting_path, method: :put
+    link_to 'Submit Spam', spam_admin_job_posting_path, method: :put, title: "Report missed spam:\nThis job posting was not flagged as spam, but should have been."
   end
 
   action_item :view, only: :show do
-    link_to 'Mark Ham', ham_admin_job_posting_path, method: :put
+    link_to 'Submit Ham', ham_admin_job_posting_path, method: :put, title: "Report false positive:\nThis job posting was flagged as spam, but should not have been."
   end
 
   # See permitted parameters documentation:

--- a/app/admin/job_posting.rb
+++ b/app/admin/job_posting.rb
@@ -7,6 +7,24 @@ ActiveAdmin.register JobPosting do
     :company
   )
 
+  member_action :spam, method: :put do
+    resource.spam!
+    redirect_to resource_path, notice: 'Marked as spam!'
+  end
+
+  member_action :ham, method: :put do
+    resource.ham!
+    redirect_to resource_path, notice: 'Marked as ham!'
+  end
+
+  action_item :view, only: :show do
+    link_to 'Mark Spam', spam_admin_job_posting_path, method: :put
+  end
+
+  action_item :view, only: :show do
+    link_to 'Mark Ham', ham_admin_job_posting_path, method: :put
+  end
+
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -11,6 +11,11 @@ class JobsController < ApplicationController
   def create
     @job = JobPosting.new(job_params)
 
+    @job.spam?
+      redirect_to new_job_path, alert: "Your job listing was automatically rejected."
+      return
+    end
+
     if @job.save
       redirect_to job_path(@job), notice: "Your job listing has been posted."
     else

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -11,13 +11,20 @@ class JobsController < ApplicationController
   def create
     @job = JobPosting.new(job_params)
 
-    @job.spam?
-      redirect_to new_job_path, alert: "Your job listing was automatically rejected."
-      return
-    end
+    # Collect and cache information required for future moderation actions
+    @job.attributes = {
+      user_ip: request.env['REMOTE_ADDR'],
+      user_agent: request.env['HTTP_USER_AGENT'],
+      referrer: request.env['HTTP_REFERER']
+    }
+    @job.akismet_spam = @job.spam?
 
     if @job.save
-      redirect_to job_path(@job), notice: "Your job listing has been posted."
+      if @job.akismet_spam
+        redirect_to job_path(@job), alert: "Your job listing has been posted, but requires moderator approval."
+      else
+        redirect_to job_path(@job), notice: "Your job listing has been posted."
+      end
     else
       render :new
    end

--- a/app/models/job_posting.rb
+++ b/app/models/job_posting.rb
@@ -10,7 +10,7 @@ class JobPosting < ActiveRecord::Base
 
   def self.current_jobs
     current_dates = 30.days.ago.beginning_of_day..Date.current.end_of_day
-    where(created_at: current_dates).order(created_at: :desc)
+    where(created_at: current_dates, akismet_spam: false).order(created_at: :desc)
   end
 
   def posted_at

--- a/app/models/job_posting.rb
+++ b/app/models/job_posting.rb
@@ -4,6 +4,10 @@ class JobPosting < ActiveRecord::Base
   validates :description, presence: true
   validates :how_to_apply, presence: true
 
+  include Rakismet::Model
+  rakismet_attrs :comment_type => 'job-post', :content => :description,
+                 :author => :company
+
   def self.current_jobs
     current_dates = 30.days.ago.beginning_of_day..Date.current.end_of_day
     where(created_at: current_dates).order(created_at: :desc)

--- a/app/views/jobs/show.html.slim
+++ b/app/views/jobs/show.html.slim
@@ -1,16 +1,24 @@
-#job.job-posting
-  .job-posting__header
-    h2.job-company=@job.company
-    h1.job-title=@job.title
-    span.job-posting-date=@job.posted_at
-    span.job-availability=@job.availability
-    .job-share=mail_to "", "Share this job", 
-      {subject: "[Chadev+Jobs] #{@job.title}", 
-        body: "Here is a job I thought you might be interested in. <br/><br/> #{job_url(@job)}"}
+- if @job.akismet_spam
 
-  .job-posting__description
-    div==markdown @job.description
+  #job.job-posting
+    .job-posting__header
+      | This job posting is awaiting moderation.
 
-  .how-to-apply
-    h1 How to apply
-    ==markdown @job.how_to_apply
+- else
+
+  #job.job-posting
+    .job-posting__header
+      h2.job-company=@job.company
+      h1.job-title=@job.title
+      span.job-posting-date=@job.posted_at
+      span.job-availability=@job.availability
+      .job-share=mail_to "", "Share this job",
+        {subject: "[Chadev+Jobs] #{@job.title}",
+          body: "Here is a job I thought you might be interested in. <br/><br/> #{job_url(@job)}"}
+
+    .job-posting__description
+      div==markdown @job.description
+
+    .how-to-apply
+      h1 How to apply
+      ==markdown @job.how_to_apply

--- a/config/initializers/rakismet.rb
+++ b/config/initializers/rakismet.rb
@@ -1,0 +1,2 @@
+Rails.application.config.rakismet.key = ENV['RAKISMET_KEY']
+Rails.application.config.rakismet.url = ENV['RAKISMET_URL']

--- a/db/migrate/20151114222751_add_spam_data_fields_to_job_posting.rb
+++ b/db/migrate/20151114222751_add_spam_data_fields_to_job_posting.rb
@@ -1,0 +1,10 @@
+class AddSpamDataFieldsToJobPosting < ActiveRecord::Migration
+  def change
+    change_table :job_postings do |t|
+      t.column :akismet_spam, :boolean, default: false
+      t.column :user_ip, :string
+      t.column :user_agent, :string
+      t.column :referrer, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150624235531) do
+ActiveRecord::Schema.define(version: 20151114222751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -36,9 +37,13 @@ ActiveRecord::Schema.define(version: 20150624235531) do
     t.text     "description"
     t.text     "how_to_apply"
     t.boolean  "full_time",    default: true
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.string   "company"
+    t.boolean  "akismet_spam", default: false
+    t.string   "user_ip"
+    t.string   "user_agent"
+    t.string   "referrer"
   end
 
   add_index "job_postings", ["company"], name: "index_job_postings_on_company", using: :btree


### PR DESCRIPTION
# Tasks remaining
 - [ ] Fix code style
 - [ ] Fix tests

# General Notes

 - Job postings created from the frontend will be filtered through Akismet.
 - Admins have the ability to review/change spam flags on individual job postings as necessary.
 - Requires two new environment variables:
   - `RAKISMET_KEY`
   - `RAKISMET_URL`

# Frontend
Not pictured: spam job postings don't show up on the homepage list.
Spam job postings `#show` pages do not display spam content by default:
![image](https://cloud.githubusercontent.com/assets/3905798/11166438/432abe7e-8b01-11e5-9a4a-9d3e96b9973e.png)

# Backend
Added "submit spam" and "submit ham" actions for individual job postings:
![image](https://cloud.githubusercontent.com/assets/3905798/11166445/6a3e78ac-8b01-11e5-9c94-bd2a8a1e19cc.png)

Trimmed up columns on job postings index:
![image](https://cloud.githubusercontent.com/assets/3905798/11166470/756891e4-8b02-11e5-8f7c-500a53b75171.png)

