### PR TITLE
Add spam:cleanup task

### DIFF
--- a/lib/tasks/spam.rake
+++ b/lib/tasks/spam.rake
@@ -1,0 +1,6 @@
+namespace :spam do
+  desc 'Deletes all job postings which have been marked as spam.'
+  task cleanup: :environment do
+     JobPosting.where(akismet_spam: true).destroy_all
+  end
+end


### PR DESCRIPTION
In order to avoid bumping up against the hobby-dev database 10,000 row limit, this task should be run via Heroku scheduler every once in a while.

```bash
$ bin/rake spam:cleanup
```